### PR TITLE
Add django-upgrade changes

### DIFF
--- a/example_project/articles/admin.py
+++ b/example_project/articles/admin.py
@@ -2,9 +2,9 @@ from django.contrib import admin
 from .models import Article
 
 
+@admin.register(Article)
 class ArticleAdmin(admin.ModelAdmin):
     list_display = ('title', 'slug', 'created_at')
     list_filter = ('created_at',)
     search_fields = ('title',)
 
-admin.site.register(Article, ArticleAdmin)

--- a/example_project/posts/admin.py
+++ b/example_project/posts/admin.py
@@ -5,6 +5,7 @@ from posts.models import Post
 from guardian.admin import GuardedModelAdmin
 
 
+@admin.register(Post)
 class PostAdmin(GuardedModelAdmin):
     prepopulated_fields = {"slug": ("title",)}
     list_display = ('title', 'slug', 'created_at')
@@ -12,4 +13,3 @@ class PostAdmin(GuardedModelAdmin):
     ordering = ('-created_at',)
     date_hierarchy = 'created_at'
 
-admin.site.register(Post, PostAdmin)

--- a/guardian/__init__.py
+++ b/guardian/__init__.py
@@ -4,8 +4,6 @@ Implementation of per object permissions for Django.
 from . import checks
 import django
 
-if django.VERSION < (3, 2):
-    default_app_config = 'guardian.apps.GuardianConfig'
 
 # PEP 396: The __version__ attribute's value SHOULD be a string.
 __version__ = '2.4.0'

--- a/guardian/testapp/tests/test_decorators.py
+++ b/guardian/testapp/tests/test_decorators.py
@@ -384,12 +384,8 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
             pass
         response = dummy_view(request, project_name='foobar')
         self.assertTrue(isinstance(response, HttpResponseRedirect))
-        if django.VERSION >= (3, 2):
-            self.assertTrue(response.headers['location'].startswith(
-                '/foobar/'))
-        else:
-            self.assertTrue(response._headers['location'][1].startswith(
-                '/foobar/'))
+        self.assertTrue(response.headers['location'].startswith(
+            '/foobar/'))
 
     @override_settings(LOGIN_URL='django.contrib.auth.views.login')
     def test_redirection_class(self):

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -550,8 +550,7 @@ class GetUsersWithPermsTest(TestCase):
         self.assertEqual(set(get_group_perms(self.group2, self.obj1)), set())
         self.assertEqual(set(get_group_perms(admin, self.obj1)), set())
         expected_permissions = ['add_contenttype', 'change_contenttype', 'delete_contenttype']
-        if django.VERSION >= (2, 1):
-            expected_permissions.append('view_contenttype')
+        expected_permissions.append('view_contenttype')
         self.assertEqual(set(get_perms(admin, self.obj1)), set(expected_permissions))
         self.assertEqual(set(get_perms(self.user1, self.obj1)), {'change_contenttype', 'delete_contenttype'})
         self.assertEqual(set(get_perms(self.user2, self.obj1)), {'delete_contenttype'})
@@ -570,8 +569,7 @@ class GetUsersWithPermsTest(TestCase):
             admin: ["add_contenttype", "change_contenttype", "delete_contenttype"],
             self.user2: ["delete_contenttype"]
         }
-        if django.VERSION >= (2, 1):
-            expected[admin].append("view_contenttype")
+        expected[admin].append("view_contenttype")
         result = get_users_with_perms(self.obj1, attach_perms=True,
             with_superusers=False, with_group_users=True)
         self.assertEqual(result.keys(), expected.keys())


### PR DESCRIPTION
As mentioned here: https://github.com/RowAnalytics/django-guardian/pull/1#issuecomment-2405073647 we would like to add some improvements to your django upgrade. We created this PR, so you can easily review the changes.

-------

Hi @ZbigniewRA,

is it possible to add the changes from https://github.com/BonaFideIT/django-guardian/commit/f46db918bcfcf068adf99ca0c28ead4a2485b0f8 to your branch?

It cleans up some admin model registration and removes some django versions checks which are not necessary anymore by your upgrade.

You can use the follow command: `git ls-files -z -- '*.py' | xargs -0 django-upgrade --target-version 5.0` in the project root.